### PR TITLE
deps: update embedded-hal to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 categories = ["embedded", "hardware-support", "no-std"]
 
 [dependencies]
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = "1.0"
 # buggy and outdated
 embedded-graphics = "0.8"
 

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -1,25 +1,23 @@
-use core::iter;
-
-use crate::interface::{DisplayError, DisplayInterface};
+use crate::interface::DisplayInterface;
 use embedded_graphics::prelude::GrayColor;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
+pub use self::il3895::*;
+pub use self::pd::*;
 pub use self::ssd1608::*;
 pub use self::ssd1619a::*;
-pub use self::ssd1680::*;
 pub use self::ssd1675b::*;
-pub use self::pd::*;
+pub use self::ssd1680::*;
 pub use self::uc8176::*;
-pub use self::il3895::*;
 pub use self::uc8179::*;
 
+mod il3895;
+mod pd;
 mod ssd1608;
 mod ssd1619a;
 mod ssd1675b;
 mod ssd1680;
-mod pd;
 mod uc8176;
-mod il3895;
 mod uc8179;
 
 pub type IL3820 = SSD1608;
@@ -31,7 +29,7 @@ pub trait Driver {
     const BLACK_BIT: bool = false;
 
     /// Wake UP and init
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error>;
@@ -45,7 +43,7 @@ pub trait Driver {
 
     fn turn_on_display<DI: DisplayInterface>(di: &mut DI) -> Result<(), Self::Error>;
 
-    fn sleep<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn sleep<DI: DisplayInterface, DELAY: DelayNs>(
         _di: &mut DI,
         _delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -99,4 +97,3 @@ pub trait GrayScaleDriver<Color: GrayColor>: WaveformDriver {
 
     fn restore_normal_waveform<DI: DisplayInterface>(di: &mut DI) -> Result<(), Self::Error>;
 }
-

--- a/src/drivers/il3895.rs
+++ b/src/drivers/il3895.rs
@@ -2,7 +2,7 @@
 
 use crate::interface::{DisplayError, DisplayInterface};
 use embedded_graphics::pixelcolor::Gray4;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, FastUpdateDriver, GrayScaleDriver, MultiColorDriver, WaveformDriver};
 
@@ -16,7 +16,7 @@ pub struct IL3895;
 impl Driver for IL3895 {
     type Error = DisplayError;
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -91,7 +91,7 @@ impl Driver for IL3895 {
         Ok(())
     }
 
-    fn sleep<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn sleep<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         _delay: &mut DELAY,
     ) -> Result<(), Self::Error> {

--- a/src/drivers/pd.rs
+++ b/src/drivers/pd.rs
@@ -2,7 +2,7 @@ use core::iter;
 
 use crate::interface::{DisplayError, DisplayInterface};
 use embedded_graphics::pixelcolor::Gray4;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, FastUpdateDriver, GrayScaleDriver, MultiColorDriver, WaveformDriver};
 
@@ -22,7 +22,7 @@ impl Driver for PervasiveDisplays {
         Ok(())
     }
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -146,7 +146,7 @@ impl Driver for PervasiveDisplays {
         Ok(())
     }
 
-    fn sleep<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn sleep<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {

--- a/src/drivers/ssd1608.rs
+++ b/src/drivers/ssd1608.rs
@@ -1,5 +1,5 @@
 use embedded_graphics::pixelcolor::{Gray2, Gray4};
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use crate::{
     color::Gray3,
@@ -15,7 +15,7 @@ pub struct SSD1608;
 impl Driver for SSD1608 {
     type Error = interface::DisplayError;
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -131,7 +131,7 @@ impl Driver for SSD1608 {
         Ok(())
     }
 
-    fn sleep<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn sleep<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         _delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -146,7 +146,7 @@ pub struct SSD1608Fast;
 impl Driver for SSD1608Fast {
     type Error = interface::DisplayError;
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {

--- a/src/drivers/ssd1619a.rs
+++ b/src/drivers/ssd1619a.rs
@@ -15,7 +15,7 @@ use core::iter;
 
 use crate::interface::{self, DisplayInterface};
 use embedded_graphics::pixelcolor::Gray4;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, FastUpdateDriver, GrayScaleDriver, MultiColorDriver, WaveformDriver};
 
@@ -27,7 +27,7 @@ pub struct SSD1619A;
 impl Driver for SSD1619A {
     type Error = interface::DisplayError;
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -114,7 +114,7 @@ impl Driver for SSD1619A {
         Ok(())
     }
 
-    fn sleep<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn sleep<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         _delay: &mut DELAY,
     ) -> Result<(), Self::Error> {

--- a/src/drivers/ssd1675b.rs
+++ b/src/drivers/ssd1675b.rs
@@ -1,7 +1,7 @@
 //! SSD1675B driver
 
 use core::iter;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, FastUpdateDriver, MultiColorDriver, WaveformDriver};
 use crate::interface::{DisplayError, DisplayInterface};
@@ -13,7 +13,7 @@ pub struct SSD1675B;
 impl Driver for SSD1675B {
     type Error = DisplayError;
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -128,7 +128,6 @@ impl WaveformDriver for SSD1675B {
         di.send_command_data(0x32, lut)
     }
 }
-
 
 // TODO: test this
 impl FastUpdateDriver for SSD1675B {

--- a/src/drivers/ssd1680.rs
+++ b/src/drivers/ssd1680.rs
@@ -6,7 +6,7 @@
 // 153 bytes LUT.
 
 use core::iter;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, FastUpdateDriver, MultiColorDriver, WaveformDriver};
 use crate::interface::{DisplayError, DisplayInterface};
@@ -17,7 +17,7 @@ pub struct SSD1680;
 impl Driver for SSD1680 {
     type Error = DisplayError;
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -77,7 +77,7 @@ impl Driver for SSD1680 {
         Ok(())
     }
 
-    fn sleep<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn sleep<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {

--- a/src/drivers/uc8176.rs
+++ b/src/drivers/uc8176.rs
@@ -1,7 +1,7 @@
 //! UC8176 driver
 
 use core::iter;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, MultiColorDriver};
 use crate::interface::{DisplayError, DisplayInterface};
@@ -19,7 +19,7 @@ impl Driver for UC8176 {
         Ok(())
     }
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {

--- a/src/drivers/uc8179.rs
+++ b/src/drivers/uc8179.rs
@@ -2,8 +2,7 @@
 //!
 //! Up to 20MHz
 
-use core::iter;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 use super::{Driver, MultiColorDriver};
 use crate::interface::{DisplayError, DisplayInterface};
@@ -22,7 +21,7 @@ impl Driver for UC8179 {
         Ok(())
     }
 
-    fn wake_up<DI: DisplayInterface, DELAY: DelayUs<u32>>(
+    fn wake_up<DI: DisplayInterface, DELAY: DelayNs>(
         di: &mut DI,
         delay: &mut DELAY,
     ) -> Result<(), Self::Error> {
@@ -80,7 +79,7 @@ impl Driver for UC8179 {
         di.send_command(0x04)?; // Power on
         Self::busy_wait(di)?;
 
-     //   di.send_command(0x12)?; // display refresh
+        //   di.send_command(0x12)?; // display refresh
 
         Self::busy_wait(di)?;
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,7 @@
 //! The display interface for e-Paper displays.
 
-use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::{InputPin, OutputPin};
 
 #[derive(Clone, Debug)]
 pub enum DisplayError {
@@ -32,159 +32,31 @@ pub trait DisplayInterface {
     where
         I: IntoIterator<Item = &'a u8>;
 
-    fn is_busy_on(&self) -> bool;
+    fn is_busy_on(&mut self) -> bool;
 
     /// Hard reset
     fn reset<D>(&mut self, delay: &mut D, initial_delay: u32, duration: u32)
     where
-        D: DelayUs<u32>;
+        D: DelayNs;
 }
 
 /// EPaperDisplay SPI display interface.
-pub struct EPDInterface<SPI, CS, DC, RST, BUSY> {
-    spi: SPI,
-    cs: CS,
-    dc: DC,
-    rst: RST,
-    busy: BUSY,
-}
-
-impl<SPI, CS, DC, RST, BUSY> EPDInterface<SPI, CS, DC, RST, BUSY>
-where
-    SPI: embedded_hal::blocking::spi::Write<u8>,
-    DC: OutputPin,
-    CS: OutputPin,
-    RST: OutputPin,
-    BUSY: InputPin,
-{
-    pub fn new(spi: SPI, cs: CS, dc: DC, rst: RST, busy: BUSY) -> Self {
-        EPDInterface {
-            spi,
-            cs,
-            dc,
-            rst,
-            busy,
-        }
-    }
-
-    /// Consume the display interface and return
-    /// the underlying peripherial driver and GPIO pins used by it
-    pub fn release(self) -> (SPI, DC, CS, BUSY) {
-        (self.spi, self.dc, self.cs, self.busy)
-    }
-}
-
-impl<SPI, CS, DC, RST, BUSY> DisplayInterface for EPDInterface<SPI, CS, DC, RST, BUSY>
-where
-    SPI: embedded_hal::blocking::spi::Write<u8>,
-    DC: OutputPin,
-    CS: OutputPin,
-    RST: OutputPin,
-    BUSY: InputPin,
-{
-    /// Send a command to the controller.
-    fn send_command(&mut self, command: u8) -> Result<(), DisplayError> {
-        // Assert chip select pin
-        self.cs.set_low().map_err(|_| DisplayError::CSError)?;
-
-        // 1 = data, 0 = command
-        self.dc.set_low().map_err(|_| DisplayError::DCError)?;
-
-        // Send words over SPI
-        let ret = self
-            .spi
-            .write(&[command])
-            .map_err(|_| DisplayError::BusWriteError);
-
-        // Deassert chip select pin
-        self.cs.set_high().ok();
-
-        ret
-    }
-
-    /// Send data for a command.
-    fn send_data(&mut self, data: &[u8]) -> Result<(), DisplayError> {
-        // Assert chip select pin
-        self.cs.set_low().map_err(|_| DisplayError::CSError)?;
-
-        // 1 = data, 0 = command
-        self.dc.set_high().map_err(|_| DisplayError::DCError)?;
-
-        // Send words over SPI
-        let ret = self
-            .spi
-            .write(data)
-            .map_err(|_| DisplayError::BusWriteError);
-
-        // Deassert chip select pin
-        self.cs.set_high().ok();
-
-        ret
-    }
-
-    fn send_data_from_iter<'a, I>(&mut self, iter: I) -> Result<usize, DisplayError>
-    where
-        I: IntoIterator<Item = &'a u8>,
-    {
-        self.cs.set_low().map_err(|_| DisplayError::CSError)?;
-        self.dc.set_high().map_err(|_| DisplayError::DCError)?;
-
-        let mut n = 0;
-        for &d in iter {
-            n += 1;
-            let ret = self
-                .spi
-                .write(&[d])
-                .map_err(|_| DisplayError::BusWriteError);
-            if ret.is_err() {
-                self.cs.set_high().ok();
-                ret?; // return the error
-            }
-        }
-
-        // Deassert chip select pin
-        self.cs.set_high().ok();
-
-        Ok(n)
-    }
-
-    fn reset<D>(&mut self, delay: &mut D, initial_delay: u32, duration: u32)
-    where
-        D: DelayUs<u32>,
-    {
-        let _ = self.rst.set_high();
-        delay.delay_us(initial_delay);
-
-        let _ = self.rst.set_low();
-        delay.delay_us(duration);
-        let _ = self.rst.set_high();
-        //TODO: the upstream libraries always sleep for 200ms here
-        // 10ms works fine with just for the 7in5_v2 but this needs to be validated for other devices
-        delay.delay_us(200_000);
-    }
-
-    fn is_busy_on(&self) -> bool {
-        self.busy.is_high().unwrap_or(false)
-    }
-}
-
-/// EPaperDisplay SPI display interface.
-pub struct EPDInterfaceNoCS<SPI, DC, RST, BUSY> {
+pub struct EPDInterface<SPI, DC, RST, BUSY> {
     spi: SPI,
     dc: DC,
     rst: RST,
     busy: BUSY,
 }
 
-impl<SPI, DC, RST, BUSY> EPDInterfaceNoCS<SPI, DC, RST, BUSY>
+impl<SPI, DC, RST, BUSY> EPDInterface<SPI, DC, RST, BUSY>
 where
-    SPI: embedded_hal::blocking::spi::Write<u8>,
+    SPI: embedded_hal::spi::SpiDevice,
     DC: OutputPin,
     RST: OutputPin,
     BUSY: InputPin,
 {
     pub fn new(spi: SPI, dc: DC, rst: RST, busy: BUSY) -> Self {
-        EPDInterfaceNoCS { spi, dc, rst, busy }
+        EPDInterface { spi, dc, rst, busy }
     }
 
     /// Consume the display interface and return
@@ -194,9 +66,9 @@ where
     }
 }
 
-impl<SPI, DC, RST, BUSY> DisplayInterface for EPDInterfaceNoCS<SPI, DC, RST, BUSY>
+impl<SPI, DC, RST, BUSY> DisplayInterface for EPDInterface<SPI, DC, RST, BUSY>
 where
-    SPI: embedded_hal::blocking::spi::Write<u8>,
+    SPI: embedded_hal::spi::SpiDevice,
     DC: OutputPin,
     RST: OutputPin,
     BUSY: InputPin,
@@ -246,13 +118,13 @@ where
         Ok(n)
     }
 
-    fn is_busy_on(&self) -> bool {
+    fn is_busy_on(&mut self) -> bool {
         self.busy.is_high().unwrap_or(false)
     }
 
     fn reset<D>(&mut self, delay: &mut D, initial_delay: u32, duration: u32)
     where
-        D: DelayUs<u32>,
+        D: DelayNs,
     {
         let _ = self.rst.set_high();
         delay.delay_us(initial_delay);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ where
 
     pub fn init<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, S::WIDTH as _, S::HEIGHT as _)?;
@@ -71,14 +71,14 @@ where
 
     pub fn sleep<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::sleep(&mut self.interface, delay)
     }
 
     pub fn wake_up<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, S::WIDTH as _, S::HEIGHT as _)?;
@@ -138,7 +138,7 @@ where
 
     pub fn init<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, S::WIDTH as _, S::HEIGHT as _)?;
@@ -166,14 +166,14 @@ where
 
     pub fn sleep<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::sleep(&mut self.interface, delay)
     }
 
     pub fn wake_up<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, S::WIDTH as _, S::HEIGHT as _)?;
@@ -230,7 +230,7 @@ where
 
     pub fn init<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, S::WIDTH as _, S::HEIGHT as _)?;
@@ -253,14 +253,14 @@ where
 
     pub fn sleep<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::sleep(&mut self.interface, delay)
     }
 
     pub fn wake_up<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, S::WIDTH as _, S::HEIGHT as _)?;
@@ -338,7 +338,7 @@ where
 
     pub fn init<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::wake_up(&mut self.interface, delay)?;
         D::set_shape(&mut self.interface, SIZE::WIDTH as _, SIZE::HEIGHT as _)?;
@@ -388,7 +388,7 @@ where
 
     pub fn sleep<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), D::Error>
     where
-        DELAY: embedded_hal::blocking::delay::DelayUs<u32>,
+        DELAY: embedded_hal::delay::DelayNs,
     {
         D::sleep(&mut self.interface, delay)
     }


### PR DESCRIPTION
- use delay::DelayNs from embedded-hal 1.0.0
- use embedded-hal 1.0.0 spi::SpiDevice instead of embedded-hal 0.2 spi::Write
- EPDInterfaceNoCS is removed; embedded-hal spi::SpiDevice automatically manages CS pin, now EPDInterface means the original EPDInterfaceNoCS